### PR TITLE
refactor: optimised page navigation in lists

### DIFF
--- a/.vitepress/theme/components/lists/ArchiveList.vue
+++ b/.vitepress/theme/components/lists/ArchiveList.vue
@@ -2,7 +2,7 @@
 import './lists.css';
 import { data as pages } from '../loaders/archives.data.js';
 import { difficultyTypes } from './difficultyTypes.js';
-import { useData } from 'vitepress';
+import { useData, useRouter } from 'vitepress';
 
 /**
  * @notes - Archived expansion banner images should be
@@ -10,6 +10,7 @@ import { useData } from 'vitepress';
  */
 
 const { frontmatter } = useData();
+const router = useRouter();
 
 const selectedDifficultyTypes = difficultyTypes.filter(difficulty =>
 	frontmatter.value.difficulties.includes(difficulty.type)
@@ -22,7 +23,7 @@ const filterPagesBy = (difficulty, expansion) => {
 };
 
 function openPage(url) {
-	window.open(url, "_self");
+	router.go(url);
 }
 </script>
 

--- a/.vitepress/theme/components/lists/PageList.vue
+++ b/.vitepress/theme/components/lists/PageList.vue
@@ -2,8 +2,11 @@
 import './lists.css';
 import { data as pages } from '../loaders/guides.data.js';
 import { difficultyTypes } from './difficultyTypes.js';
-import { useData } from 'vitepress'
-let pageData = useData();
+import { useData, useRouter } from 'vitepress';
+
+const pageData = useData();
+const router = useRouter();
+
 defineProps(['limitedList']);
 
 /**
@@ -18,20 +21,19 @@ defineProps(['limitedList']);
  */
 
 const filterPagesBy = (difficulty) => {
-  let filteredPages = pages
-      .filter(p => p.frontmatter.difficulty === difficulty)
-      .sort((a, b) => a.frontmatter.order - b.frontmatter.order)
+	let filteredPages = pages
+		.filter(p => p.frontmatter.difficulty === difficulty)
+		.sort((a, b) => a.frontmatter.order - b.frontmatter.order);
 
-  if (difficulty === 'Savage' && pageData.frontmatter.value.layout === 'home') {
-    return filteredPages.slice(-4); // Limit to the last 4 pages for Savage
-  } else {
-    return filteredPages;
-  }
+	if (difficulty === 'Savage' && pageData.frontmatter.value.layout === 'home') {
+		return filteredPages.slice(-4); // Limit to the last 4 pages for Savage
+	} else {
+		return filteredPages;
+	}
 };
 
 function openPage(url) {
-	let strippedUrl = url.replace("/guides", '').toLowerCase();
-	window.open(strippedUrl, "_self");
+	router.go(url.replace("/guides", '').toLowerCase());
 }
 </script>
 

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -64,8 +64,6 @@ export default {
 			},
 		});
 
-		ctx.app.config.globalProperties
-
 		if (typeof window !== 'undefined') {
 			window.createTooltip = createTooltip;
 		}

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -64,9 +64,13 @@ export default {
 			},
 		});
 
+		ctx.app.config.globalProperties
+
 		if (typeof window !== 'undefined') {
 			window.createTooltip = createTooltip;
 		}
+
+		console.log("Hello!")
 	},
 	setup() {
 		// Get route

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -69,8 +69,6 @@ export default {
 		if (typeof window !== 'undefined') {
 			window.createTooltip = createTooltip;
 		}
-
-		console.log("Hello!")
 	},
 	setup() {
 		// Get route


### PR DESCRIPTION
- In the `openPage()` functions in the list components, changed to navigating using Vitepress' `useRouter()` hook instead of the window API, which caused a slower full-page reload.