### PR TITLE
fix?(useScrollDirection): potential fix for Safari mobile nav-hiding behaviour

### DIFF
--- a/.vitepress/theme/hooks/useScrollDirection.ts
+++ b/.vitepress/theme/hooks/useScrollDirection.ts
@@ -2,24 +2,33 @@
  * Listens to the user's scroll direction, 
  * accepts a callback with a boolean of a downward scroll.
  * 
+ * Options:
  * @param isMobile - Listen only during mobile widths (960px). False by default.
+ * @param pageTopTreshold - Sets a threshold scroll distance past the top of the page in order for the callback to occur. Zero by default.
  */
 export default function useScrollDirection(
   onDirectionChange: (isDown: boolean) => void,
-  { isMobile = false }: { isMobile: boolean }
+  options?: {
+    isMobile?: boolean,
+    pageTopThreshold?: number
+  }
 ): void {
+  const isMobile = options?.isMobile ?? false;
+  const pageTopThreshold = options?.pageTopThreshold ?? 0;
+
   let lastScrollY = 0;
   let scrolledDownFlag = false;
 
   const scrollListener = () => {
-    const isScrollingDown = window.scrollY > lastScrollY;
+    const newY = window.scrollY;
+    const isScrollingDown = newY > lastScrollY && newY > pageTopThreshold;
 
     if (isScrollingDown !== scrolledDownFlag) {
       onDirectionChange(isScrollingDown);
       scrolledDownFlag = isScrollingDown;
     }
 
-    lastScrollY = window.scrollY;
+    lastScrollY = newY;
   }
 
   const updateScrollListener = () => {

--- a/.vitepress/theme/layouts/guide.vue
+++ b/.vitepress/theme/layouts/guide.vue
@@ -14,17 +14,12 @@ const icon = computed(() => difficultyTypes.find(t => t.type === frontmatter.val
 onMounted(() => {
 	const root = document.documentElement;
 
-	useScrollDirection(isDown => {
-		if (isDown) {
-			root.style.setProperty("--nav-top", "-64px");
-			root.style.setProperty("--local-nav-top", "0");
-		} else {
-			root.style.setProperty("--nav-top", "0");
-			root.style.setProperty("--local-nav-top", "64px");
-		}
-	}, {
-		isMobile: true
-	});
+	const hideNav = (hide) => {
+		root.style.setProperty("--nav-top", hide ? "-64px" : "0");
+		root.style.setProperty("--local-nav-top", hide ? "0" : "64px");
+	};
+
+	useScrollDirection(hideNav, { isMobile: true, pageTopThreshold: 150 });
 });
 </script>
 
@@ -57,23 +52,13 @@ onMounted(() => {
 						</template>
 						<template v-for="(author, idx) in frontmatter.authors" :key="author">
 							<span class="author">
-								<svg
-									width="16px"
-									height="16px"
-									viewBox="0 0 24 24"
-									fill="none"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<path
-										fill-rule="evenodd"
-										clip-rule="evenodd"
+								<svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+									<path fill-rule="evenodd" clip-rule="evenodd"
 										d="M16 7C16 9.20914 14.2091 11 12 11C9.79086 11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7ZM14 7C14 8.10457 13.1046 9 12 9C10.8954 9 10 8.10457 10 7C10 5.89543 10.8954 5 12 5C13.1046 5 14 5.89543 14 7Z"
-										fill="currentColor"
-									/>
+										fill="currentColor" />
 									<path
 										d="M16 15C16 14.4477 15.5523 14 15 14H9C8.44772 14 8 14.4477 8 15V21H6V15C6 13.3431 7.34315 12 9 12H15C16.6569 12 18 13.3431 18 15V21H16V15Z"
-										fill="currentColor"
-									/>
+										fill="currentColor" />
 								</svg>
 								{{ author }}<span v-if="idx < frontmatter.authors.length - 1">,</span>
 							</span>
@@ -125,6 +110,7 @@ onMounted(() => {
 	flex-wrap: wrap;
 	gap: 0.2em;
 }
+
 .author {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
- Added a specifiable scroll distance threshold past the top of the page in order for the nav bar to hide when scrolling down. Potentially fixes unwanted behaviour on Safari mobile. 