### PR TITLE
feat(GuideHome): Added responsive masonry layout

### DIFF
--- a/.vitepress/theme/components/lists/GuideButton.vue
+++ b/.vitepress/theme/components/lists/GuideButton.vue
@@ -1,10 +1,10 @@
-<script setup lang="ts">
+<script setup>
 import {difficultyTypes} from "./difficultyTypes";
 import {useRouter} from "vitepress";
 
 const router = useRouter();
 
-function openPage(url: string) {
+function openPage(url) {
 	router.go(url.replace("/guides", "").toLowerCase());
 }
 

--- a/.vitepress/theme/components/lists/GuideHome.vue
+++ b/.vitepress/theme/components/lists/GuideHome.vue
@@ -57,7 +57,6 @@ function getArchiveColumns(expansion) {
 
 <style scoped>
 .navblock {
-	margin-top: 16px;
 	column-gap: 0.8rem;
 	/* flex-direction: row-reverse;  */
 }

--- a/.vitepress/theme/components/lists/GuideHome.vue
+++ b/.vitepress/theme/components/lists/GuideHome.vue
@@ -1,8 +1,9 @@
-<script setup lang="ts">
+<script setup>
 import GuideList from "./GuideList.vue";
-import {difficultyTypes} from "./difficultyTypes";
+import { difficultyTypes } from "./difficultyTypes";
+import { data as archivePages } from "../loaders/archives.data";
 
-const {isArchive, expansion} = defineProps({
+const { isArchive, expansion, grouping } = defineProps({
 	isArchive: {
 		type: Boolean,
 		default: false,
@@ -16,27 +17,48 @@ const {isArchive, expansion} = defineProps({
 		default: false,
 	},
 });
+
+const defaultCols = { default: 5, 1250: 4, 1000: 3, 700: 2, 400: 1 };
+
+function getArchiveColumns(expansion) {
+	const difficulties = new Map();
+	archivePages
+		.filter(p => p.frontmatter.expansion === expansion)
+		.forEach(p => difficulties.set(p.frontmatter.difficulty, null));
+
+	if (difficulties.size > defaultCols.default) {
+		return defaultCols;
+	}
+
+	const trimmedCols = { default: difficulties.size };
+	for (const [key, value] of Object.entries(defaultCols)) {
+		if (key !== "default" && value <= difficulties.size) {
+			trimmedCols[key] = value;
+		}
+	}
+
+	return trimmedCols;
+}
 </script>
 
 <template>
-	<div class="navblock">
+	<masonry :cols="isArchive ? getArchiveColumns(expansion) : defaultCols" class="navblock">
 		<template v-for="difficulty in difficultyTypes" :key="difficulty.type">
-			<GuideList
-				:difficulty="difficulty.type"
-				:includeTitle="true"
-				:grouping="grouping"
+			<GuideList 
+				:difficulty="difficulty.type" 
+				:includeTitle="true" 
+				:grouping="grouping" 
 				:isArchiveList="isArchive"
-				:expansion="expansion" />
+				:expansion="expansion" 
+			/>
 		</template>
-	</div>
+	</masonry>
 </template>
 
 <style scoped>
 .navblock {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-	margin-top: 1.5em;
-	column-gap: 0.5rem;
-	row-gap: 0.5rem;
+	margin-top: 16px;
+	column-gap: 0.8rem;
+	/* flex-direction: row-reverse;  */
 }
 </style>

--- a/.vitepress/theme/components/lists/GuideList.vue
+++ b/.vitepress/theme/components/lists/GuideList.vue
@@ -148,12 +148,12 @@ function openPage(url) {
 
 .navtitle {
 	display: flex;
-	height: 60px;
-	margin-top: 6.5px;
+	height: 50px;
+	margin-top: 16.5px;
 	margin-bottom: 4.8px;
 	padding-top: 12px;
 	letter-spacing: -0.02em;
-	font-size: 24px;
+	font-size: 1.4em;
 	font-weight: 600;
 	outline: none;
 	cursor: pointer;
@@ -168,8 +168,9 @@ function openPage(url) {
 }
 
 .navtitle_img {
-	height: 1em;
+	height: 1.2em;
 	margin-right: 7px;
+	margin-left: 7px;
 	box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
 }
 

--- a/.vitepress/theme/components/lists/GuideList.vue
+++ b/.vitepress/theme/components/lists/GuideList.vue
@@ -147,9 +147,12 @@ function openPage(url) {
 }
 
 .navtitle {
-	height: 50px;
+	display: flex;
+	height: 60px;
+	margin-top: 6.5px;
+	margin-bottom: 4.8px;
+	padding-top: 12px;
 	letter-spacing: -0.02em;
-	line-height: 32px;
 	font-size: 24px;
 	font-weight: 600;
 	outline: none;
@@ -157,6 +160,7 @@ function openPage(url) {
 	transition: 0.2s ease;
 	align-content: center;
 	user-select: none;
+	align-items: center;
 
 	&:hover {
 		color: var(--vp-c-brand);
@@ -164,23 +168,19 @@ function openPage(url) {
 }
 
 .navtitle_img {
-	display: inline;
 	height: 1em;
-	vertical-align: bottom;
 	margin-right: 7px;
-	margin-bottom: 3px;
 	box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
 }
 
 .group-header {
 	font-size: 1em;
 	font-weight: 500;
-	margin-top: 0.2em;
-	margin-bottom: 0.4em;
+	padding: 0.5em 0;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	justify-content: center;
+	/* justify-content: center; */
 	user-select: none;
 	transition: color 0.2s ease;
 	color: var(--vp-c-text-3);

--- a/.vitepress/theme/components/lists/difficultyTypes.ts
+++ b/.vitepress/theme/components/lists/difficultyTypes.ts
@@ -1,9 +1,9 @@
 export const difficultyTypes = [
-	{ type: 'Extreme', icon: '/images/icons/trial.webp', colorClass: 'extreme-color', order: 1 },
 	{ type: 'Chaotic', icon: '/images/icons/chaotic.webp', colorClass: 'chaotic-color', order: 5 },
+	{ type: 'Unreal', icon: '/images/icons/trial.webp', colorClass: 'unreal-color', order: 6 },
+	{ type: 'Extreme', icon: '/images/icons/trial.webp', colorClass: 'extreme-color', order: 1 },
 	{ type: 'Savage', icon: '/images/icons/raid.webp', colorClass: 'savage-color', order: 2 },
 	{ type: 'Ultimate', icon: '/images/icons/highendduty.webp', colorClass: 'ultimate-color', order: 3 },
 	{ type: 'Criterion', icon: '/images/icons/variant.webp', colorClass: 'criterion-color', order: 4 },
-	{ type: 'Unreal', icon: '/images/icons/trial.webp', colorClass: 'unreal-color', order: 6 },
 	{ type: 'Field Operations', icon: '/images/icons/fieldops.webp', colorClass: 'fieldops-color', urlOverride: 'fieldops', order: 7 },
 ];

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,3 +1,4 @@
+//@ts-ignore
 import DefaultTheme from "vitepress/theme";
 import "viewerjs/dist/viewer.min.css";
 import imageViewer from "vitepress-plugin-image-viewer";

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -5,39 +5,26 @@ import {EnhanceAppContext, useRoute} from "vitepress";
 import "./custom.css";
 import FloatingVue, {createTooltip} from "floating-vue";
 import "floating-vue/dist/style.css";
+import masonry from "vue-next-masonry";
 
 // Nolebase imports
-// @ts-ignore
-import {InjectionKey, LayoutMode, Options} from "@nolebase/vitepress-plugin-enhanced-readabilities/client";
+import {InjectionKey, LayoutMode, Options} from "@nolebase/vitepress-plugin-enhanced-readabilities"
 import "@nolebase/vitepress-plugin-enhanced-readabilities/client/style.css";
 
-// @ts-ignore
 import YoutubeEmbed from "./components/YoutubeEmbed.vue";
-// @ts-ignore
 import TimingWindow from "./components/TimingWindow.vue";
-// @ts-ignore
 import ImageEmbed from "./components/ImageEmbed.vue";
-// @ts-ignore
 import StatusIcon from "./components/StatusIcon.vue";
-// @ts-ignore
 import Raidplan from "./components/Raidplan.vue";
-// @ts-ignore
 import Action from "./components/Action.vue";
-// @ts-ignore
 import ActionGroup from "./components/ActionGroup.vue";
-// @ts-ignore
 import CustomBlock from "./components/CustomBlock.vue";
-// @ts-ignore
 import GuideList from "./components/lists/GuideList.vue";
-// @ts-ignore
 import GuideButton from "./components/lists/GuideButton.vue";
-// @ts-ignore
 import GuideHome from "./components/lists/GuideHome.vue";
-// @ts-ignore
 import PartyFinder from "./components/PartyFinder.vue";
-
-// @ts-ignore
 import guide from "./layouts/guide.vue";
+import { PluginOption } from "vite";
 
 declare global {
 	interface Window {
@@ -74,6 +61,8 @@ export default {
 				},
 			},
 		});
+
+		masonry.install(ctx.app, {} as PluginOption);
 
 		if (typeof window !== "undefined") {
 			window.createTooltip = createTooltip;

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,4 +1,3 @@
-//@ts-ignore
 import DefaultTheme from "vitepress/theme";
 import "viewerjs/dist/viewer.min.css";
 import imageViewer from "vitepress-plugin-image-viewer";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "floating-vue": "^5.2.2",
         "gray-matter": "^4.0.3",
         "lodash": "^4.17.21",
-        "pluralize": "^8.0.0"
+        "pluralize": "^8.0.0",
+        "vue-next-masonry": "^1.1.3"
       },
       "devDependencies": {
         "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.17.2",
@@ -3549,6 +3550,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-next-masonry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vue-next-masonry/-/vue-next-masonry-1.1.3.tgz",
+      "integrity": "sha512-iY7Hy7Yyno4NE2ZWpbkINHhBdySZ/GfkubleR73CfIbv0uA4jTTl9nCcwErnGMTBIIlGYDl8gZr0OG/vFCy7JQ==",
+      "peerDependencies": {
+        "vue": "^3.0.5"
       }
     },
     "node_modules/vue-resize": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "floating-vue": "^5.2.2",
     "gray-matter": "^4.0.3",
     "lodash": "^4.17.21",
-    "pluralize": "^8.0.0"
+    "pluralize": "^8.0.0",
+    "vue-next-masonry": "^1.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
+      vue-next-masonry:
+        specifier: ^1.1.3
+        version: 1.1.3(vue@3.5.13)
     devDependencies:
       '@nolebase/vitepress-plugin-enhanced-readabilities':
         specifier: ^2.17.2
@@ -1250,6 +1253,11 @@ packages:
       postcss:
         optional: true
 
+  vue-next-masonry@1.1.3:
+    resolution: {integrity: sha512-iY7Hy7Yyno4NE2ZWpbkINHhBdySZ/GfkubleR73CfIbv0uA4jTTl9nCcwErnGMTBIIlGYDl8gZr0OG/vFCy7JQ==}
+    peerDependencies:
+      vue: ^3.0.5
+
   vue-resize@2.0.0-alpha.1:
     resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
     peerDependencies:
@@ -2439,6 +2447,10 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
+
+  vue-next-masonry@1.1.3(vue@3.5.13):
+    dependencies:
+      vue: 3.5.13
 
   vue-resize@2.0.0-alpha.1(vue@3.5.13):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "skipLibCheck": true,
-    "types": ["vitepress/client"]
+    "types": ["vitepress/client"],
   },
   "include": [
     "docs/**/*.ts",


### PR DESCRIPTION
- Proposing responsive masonry layout for `GuideHome.vue`.

Other:
- Removed `//@ts-ignore` lines in `theme/index.ts`. I think tsconfig.json is already setup correctly; there are no errors on my end.

![image](https://github.com/user-attachments/assets/c95714df-cb3b-4d83-9b7b-61d2f4d4c033)
