### PR TITLE
fix(guide.vue): fix title/header-anchor attributes

### DIFF
--- a/.vitepress/theme/layouts/guide.vue
+++ b/.vitepress/theme/layouts/guide.vue
@@ -30,9 +30,9 @@ onMounted(() => {
 			<div v-if="frontmatter.expansion && frontmatter.difficulty" class="guide_subtitle">
 				{{ frontmatter.expansion }} - {{ frontmatter.difficulty }} - {{ frontmatter.fightID }}
 			</div>
-			<h1 v-if="frontmatter.fightID" class="guide_title" id="{{frontmatter.title}}">
+			<h1 v-if="frontmatter.fightID" class="guide_title" :id="frontmatter.title">
 				<img :src="icon" /> {{ frontmatter.title }}
-				<a href="{{frontmatter.fightID}}" class="header-anchor" />
+				<a :href="frontmatter.fightID.toLowerCase()" class="header-anchor" ></a>
 			</h1>
 			<div v-if="frontmatter.difficulty" class="guide_label_box">
 				<a v-if="frontmatter.difficulty?.toLowerCase() === 'ultimate'" href="https://discord.gg/ArZz3b8PZV"


### PR DESCRIPTION
- Fixed guides' title id and anchor tag href attributes.

Before:
![image](https://github.com/user-attachments/assets/43fecc15-b945-4b40-916d-4e28601b9be8)
![image](https://github.com/user-attachments/assets/80e117a4-dbc4-465d-ad12-b64e618af2b1)

