### PR TITLE
feat(router loading bar): added a loading bar for user feedback when navigating between routes

### DIFF
--- a/.vitepress/theme/hooks/useRouterLoadingBar.ts
+++ b/.vitepress/theme/hooks/useRouterLoadingBar.ts
@@ -1,0 +1,17 @@
+export default function useRouterLoadingBar() {
+  function loading() {
+    const loadingBar = document.getElementById("loading-bar");
+    if (!loadingBar) { return; }
+    loadingBar.classList.remove("finished");
+    loadingBar.classList.add("loading");
+  }
+
+  function finished() {
+    const loadingBar = document.getElementById("loading-bar");
+    if (!loadingBar) { return; }
+    loadingBar.classList.replace("loading", "finished");
+    setTimeout(() => { loadingBar.classList.remove("finished") }, 300);
+  }
+
+  return { loading, finished }
+}

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -19,6 +19,7 @@ import GuideButton from "./components/lists/GuideButton.vue";
 import GuideHome from "./components/lists/GuideHome.vue";
 import PartyFinder from "./components/PartyFinder.vue";
 import guide from "./layouts/guide.vue";
+import useRouterLoadingBar from "./hooks/useRouterLoadingBar";
 
 declare global {
 	interface Window {
@@ -56,6 +57,10 @@ export default {
 			},
 		});
 
+		const loadingBar = useRouterLoadingBar();
+		ctx.router.onBeforePageLoad = () => loadingBar.loading();
+		ctx.router.onAfterPageLoad = () => loadingBar.finished();
+		
 		if (typeof window !== "undefined") {
 			window.createTooltip = createTooltip;
 		}

--- a/.vitepress/theme/layouts/guide.vue
+++ b/.vitepress/theme/layouts/guide.vue
@@ -25,6 +25,9 @@ onMounted(() => {
 
 <template>
 	<Layout>
+		<template #layout-top>
+			<div id="loading-bar"></div>
+		</template>
 		<template #doc-before>
 			<img v-if="frontmatter.image" :src="`/images/${frontmatter.image}`" alt="DKT" width="150" style="float: right" />
 			<div v-if="frontmatter.expansion && frontmatter.difficulty" class="guide_subtitle">
@@ -32,7 +35,7 @@ onMounted(() => {
 			</div>
 			<h1 v-if="frontmatter.fightID" class="guide_title" :id="frontmatter.title">
 				<img :src="icon" /> {{ frontmatter.title }}
-				<a :href="frontmatter.fightID.toLowerCase()" class="header-anchor" ></a>
+				<a :href="frontmatter.fightID.toLowerCase()" class="header-anchor"></a>
 			</h1>
 			<div v-if="frontmatter.difficulty" class="guide_label_box">
 				<a v-if="frontmatter.difficulty?.toLowerCase() === 'ultimate'" href="https://discord.gg/ArZz3b8PZV"
@@ -166,5 +169,30 @@ onMounted(() => {
 
 .header-anchor::before {
 	content: var(--vp-header-anchor-symbol);
+}
+
+#loading-bar {
+	opacity: 0;
+	width: 0;
+	height: 2.5px;
+	background: linear-gradient(120deg, #c77676 10%, #ebd2b4);
+	z-index: 99;
+	position: fixed;
+	top: 0;
+	left: 0;
+	transform-origin: left;
+	transition: width ease-out;
+	transition-duration: 4s;
+}
+
+#loading-bar.loading {
+	opacity: 1;
+	width: 80%;
+}
+
+#loading-bar.finished {
+	opacity: 1;
+	transition-duration: 0.2s;
+	width: 100%;
 }
 </style>


### PR DESCRIPTION
Proposing a loading bar at the top of the page (similar to YouTube/GitHub) when the user is navigating between page routes. Simply uses CSS animations for user feedback; does not reflect/affect actual page loading time.

<img width="1919" height="369" alt="image" src="https://github.com/user-attachments/assets/ab493ee7-12ec-416e-8408-80c905c5f2c5" />
