### PR TITLE
feat(router loading bar): added a time threshold in order for the loading bar to display.

### DIFF
--- a/.vitepress/theme/hooks/useRouterLoadingBar.ts
+++ b/.vitepress/theme/hooks/useRouterLoadingBar.ts
@@ -1,17 +1,17 @@
 export default function useRouterLoadingBar() {
   function loading() {
     const loadingBar = document.getElementById("loading-bar");
-    if (!loadingBar) { return; }
+    if (!loadingBar) return;
     loadingBar.classList.remove("finished");
     loadingBar.classList.add("loading");
   }
 
   function finished() {
     const loadingBar = document.getElementById("loading-bar");
-    if (!loadingBar) { return; }
+    if (!loadingBar) return;
     loadingBar.classList.replace("loading", "finished");
-    setTimeout(() => { loadingBar.classList.remove("finished") }, 300);
+    setTimeout(() => loadingBar.classList.remove("finished"), 300);
   }
 
-  return { loading, finished }
+  return { loading, finished };
 }


### PR DESCRIPTION
If the loading time is less than a given threshold, then the loading bar will not display. Intended to remove unnecessary feedback, such as from instant page loads from cache.